### PR TITLE
Fix broken "Get started" button link on index.html

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,7 +9,7 @@
       Our <b>Design once, run anywhere</b> workflows and pipelines can be designed in the Hop Gui and run on the Hop native engine (local or remote), or on Spark, Flink, Google Dataflow or AWS EMR through Beam.
       <b>Lifecycle Management</b> enables developers and administrators to switch between projects, environments and purposes without leaving your train of thought.
     </p>
-    <p><a class="button-dark" href="./manual/latest/getting-started.html">Get started</a></p>
+    <p><a class="button-dark" href="./manual/latest/getting-started/">Get started</a></p>
   </div>
   <img src="./img/hop-logo.svg" alt="Apache Hop (Incubating) - Hop Orchestration Platform">
 </header>


### PR DESCRIPTION
The link under **Documentation** -> **Getting started** works and is the same.